### PR TITLE
更新抓取图片保存时路径

### DIFF
--- a/src/admin/controller/api/file.js
+++ b/src/admin/controller/api/file.js
@@ -1,6 +1,6 @@
-import fs from 'fs';
 import path from 'path';
 import Base from './base';
+import url from 'url';
 
 export default class extends Base {
   uploadConfig = {};
@@ -22,7 +22,7 @@ export default class extends Base {
 
         // 如果是本地上传
         if (type === 'local' || !type) {
-          return this.success(think.UPLOAD_BASE_URL + result);
+          return this.success(url.resolve(think.UPLOAD_BASE_URL, result));
         }
 
         return this.serviceUpload(type, path.join(think.RESOURCE_PATH, result), config);

--- a/src/admin/controller/api/file.js
+++ b/src/admin/controller/api/file.js
@@ -10,13 +10,25 @@ export default class extends Base {
   }
 
   async postAction() {
+    let {type} = this.uploadConfig;
+    let config = this.uploadConfig;
+
     /** 处理远程抓取 **/
     if( this.post('fileUrl') ) {
-      return this.serviceUpload(
-        'remote', 
-        this.post('fileUrl'), 
-        {name: this.post('name')}
-      );
+      try {
+        // 先存到本地
+        const uploader = think.service('upload/remote', 'admin');
+        const result = await (new uploader()).run(this.post('fileUrl'), {name: this.post('name')});
+
+        // 如果是本地上传
+        if (type === 'local' || !type) {
+          return this.success(think.UPLOAD_BASE_URL + result);
+        }
+
+        return this.serviceUpload(type, path.join(think.RESOURCE_PATH, result), config);
+      } catch (e) {
+        this.fail(e || 'FILE_UPLOAD_ERROR');
+      }
     }
 
     let file = this.file('file');
@@ -31,8 +43,6 @@ export default class extends Base {
     // let contentType = file.headers['content-type']; 
 
     // 处理其它上传
-    let {type} = this.uploadConfig;
-    let config = this.uploadConfig;
     
     if( !type ) { return this.fail(); }
     if(type == 'local') {

--- a/src/admin/service/upload/base.js
+++ b/src/admin/service/upload/base.js
@@ -8,7 +8,7 @@ export default class extends think.service.base {
 
   // 域名不带http/https自动补全http
   getAbsOrigin(origin) {
-    const reg = /^https?:\/\/.+/;
+    const reg = /^(https?:)?\/\/.+/;
     if (!reg.test(origin)) {
       return `http://${origin}`;
     }

--- a/src/admin/service/upload/local.js
+++ b/src/admin/service/upload/local.js
@@ -1,6 +1,7 @@
 import path from 'path';
 import fs from 'fs';
 import Base from './base';
+import url from 'url';
 
 const moveFile = think.promisify(fs.rename, fs);
 export default class extends Base {
@@ -15,8 +16,11 @@ export default class extends Base {
     }
 
     try {
-      await moveFile(file, path.join(destPath, basename));
-      return think.UPLOAD_BASE_URL + path.join(think.UPLOAD_PATH.replace(think.RESOURCE_PATH, ''), destDir, basename);
+      // 上传文件路径
+      let filepath = path.join(destPath, basename);
+
+      await moveFile(file, filepath);
+      return url.resolve(think.UPLOAD_BASE_URL, filepath.replace(think.RESOURCE_PATH, ''));
     } catch(e) {
       throw Error('FILE_UPLOAD_MOVE_ERROR');
     }

--- a/src/admin/service/upload/local.js
+++ b/src/admin/service/upload/local.js
@@ -16,7 +16,7 @@ export default class extends Base {
 
     try {
       await moveFile(file, path.join(destPath, basename));
-      return path.join('/static/upload', destDir, basename);
+      return path.join(think.UPLOAD_PATH.replace(think.RESOURCE_PATH, ''), destDir, basename);
     } catch(e) {
       throw Error('FILE_UPLOAD_MOVE_ERROR');
     }

--- a/src/admin/service/upload/remote.js
+++ b/src/admin/service/upload/remote.js
@@ -36,7 +36,7 @@ export default class extends Base {
     }
 
     result = await putFileContent( path.join(destPath, basename), result.body, 'binary');
-    return path.join('/static/upload', destDir, basename);
+    return path.join(think.UPLOAD_PATH.replace(think.RESOURCE_PATH, ''), destDir, basename);
   }
 
   async run(file, config) {

--- a/www/static/src/common/component/editor/index.jsx
+++ b/www/static/src/common/component/editor/index.jsx
@@ -418,7 +418,7 @@ class MdEditor extends Base {
     this._preInputText("![图片上传中…]", 0, 9);
     return firekylin.upload(data).then(res => {
       let start = this._cleanSelect();
-      const reg = /^https?:\/\/.+/;
+      const reg = /^(https?:)?\/\/.+/;
       if (!reg.test(res.data)) {
         res.data = location.origin + res.data;
       }


### PR DESCRIPTION
`think.UPLOAD_PATH`是绝对路径, 需要把静态资源根路径替换掉, 本地亲测通过~

配置:
```
UPLOAD_PATH: path.join(__dirname, 'image')
```

生成:
```
/image/20170401/a649e147108982f283fec4c30b7c44a2.png"
```