### PR TITLE
修复自定义首页无效

### DIFF
--- a/www/static/src/admin/component/options_reading.jsx
+++ b/www/static/src/admin/component/options_reading.jsx
@@ -102,10 +102,20 @@ module.exports = class extends Base {
           onInvalidSubmit={this.handleInvalidSubmit.bind(this)}
           >
             <RadioGroup
-                defaultValue="recent"
-                name="frontPage"
-                label="自定义站点首页"
-                help={<span>设置页面为首页之后仍可以通过 <a href={postListUrl}>{postListUrl}</a> 访问最新发布的文章</span>}
+              onChange={e => {
+                if (e.target.value === 'page') {
+                  let options = {
+                    frontPagePage: this.refs.frontPagePage.value
+                  };
+                  this.setState({
+                    options
+                  });
+                }
+              }}
+              defaultValue="recent"
+              name="frontPage"
+              label="自定义站点首页"
+              help={<span>设置页面为首页之后仍可以通过 <a href={postListUrl}>{postListUrl}</a> 访问最新发布的文章</span>}
             >
               <Radio value="recent" label="显示最新发布的文章" />
               <Radio value="page" label={<div>


### PR DESCRIPTION
原因是由于设置逻辑是在`<select>`组件的`onChange`事件, 而如果只有一个 page 的时候不触发`onChange`事件, so添加了单选按钮组的`onChange`事件, 本地测试通过:

1. 显示最新发布的文章设置
1. 只有一个 page 时设置
1. 有多个 page 时设置
1. 刷新时默认选中