### PR TITLE
添加home页面内标签列表和最近十篇文章列表数据

### DIFF
--- a/src/home/controller/base.js
+++ b/src/home/controller/base.js
@@ -62,6 +62,11 @@ export default class extends think.controller.base {
     let tagList = await tagModel.getTagArchive();
     this.assign('tags', tagList);
 
+    // 最近10条文章
+    let postModel = this.model('post');
+    let lastPostList = await postModel.getLastPostList();
+    this.assign('lastPostList', lastPostList);
+
     this.assign('currentYear', (new Date()).getFullYear());
   }
   /**

--- a/src/home/controller/base.js
+++ b/src/home/controller/base.js
@@ -57,6 +57,11 @@ export default class extends think.controller.base {
     let categories = await this.model('cate').getCateArchive();
     this.assign('categories', categories);
 
+    // 所有标签
+    let tagModel = this.model('tag');
+    let tagList = await tagModel.getTagArchive();
+    this.assign('tags', tagList);
+
     this.assign('currentYear', (new Date()).getFullYear());
   }
   /**

--- a/src/home/controller/index.js
+++ b/src/home/controller/index.js
@@ -55,10 +55,6 @@ export default class extends Base {
     let postList = postModel.getPostSitemapList();
     this.assign('postList', postList);
 
-    let tagModel = this.model('tag');
-    let tagList = tagModel.getTagArchive();
-    this.assign('tags', tagList);
-
     this.type('text/xml');
     return this.display(this.HOME_VIEW_PATH + 'sitemap.xml');
   }

--- a/src/home/controller/post.js
+++ b/src/home/controller/post.js
@@ -126,9 +126,6 @@ export default class extends Base {
   }
 
   async tagAction() {
-    let model = this.model('tag');
-    let data = await model.getTagArchive();
-    this.assign('list', data);
     return this.displayView('tag');
   }
   /**

--- a/src/home/model/post.js
+++ b/src/home/model/post.js
@@ -46,6 +46,19 @@ export default class extends think.model.relation {
     }
     return where;
   }
+
+  /**
+   * 获取最近的10条数据 - 有缓存
+   *
+   * @return {Promise}
+   */
+  getLastPostList() {
+    return think.cache('lastPostList', async () => {
+      let postList = await this.getPostList();
+      return postList.data;
+    });
+  }
+
   /**
    * get post list
    * @param  {[type]} page  [description]

--- a/src/home/model/tag.js
+++ b/src/home/model/tag.js
@@ -20,37 +20,45 @@ export default class extends think.model.relation {
     return data.slice(0, 5);
   }
 
-  async getTagArchive() {
-    let data = await this.model('post_tag')
-      .join({
-        table: 'post',
-        on: ['post_id', 'id']
-      })
-      .join({
-        table: 'tag',
-        on: ['tag_id', 'id']
-      })
-      .where({
-        type: 0,
-        status: 3,
-        is_public: 1
-      })
-      .order('update_time DESC')
-      .select();
+  /**
+   * 获取标签数据
+   *
+   * @return {Promise}
+   */
+  getTagArchive() {
+    return think.cache('tags', async () => {
+      let data = await this.model('post_tag')
+        .join({
+          table: 'post',
+          on: ['post_id', 'id']
+        })
+        .join({
+          table: 'tag',
+          on: ['tag_id', 'id']
+        })
+        .where({
+          type: 0,
+          status: 3,
+          is_public: 1
+        })
+        .order('update_time DESC')
+        .select();
 
-    let result = {};
-    for(let tag of data) {
-      if(result[tag.pathname]) {
-        result[tag.pathname].count += 1;
-      } else {
-        result[tag.pathname] = {
-          name: tag.name,
-          pathname: encodeURIComponent(tag.pathname),
-          update_time: tag.update_time,
-          count: 1
-        };
+      let result = {};
+      for(let tag of data) {
+        if(result[tag.pathname]) {
+          result[tag.pathname].count += 1;
+        } else {
+          result[tag.pathname] = {
+            name: tag.name,
+            pathname: encodeURIComponent(tag.pathname),
+            update_time: tag.update_time,
+            count: 1
+          };
+        }
       }
-    }
-    return Object.values(result).sort((a, b)=> a.count>b.count ? -1 : 1);
+
+      return Object.values(result).sort((a, b)=> a.count>b.count ? -1 : 1);
+    });
   }
 }

--- a/www/theme/firekylin/tag.html
+++ b/www/theme/firekylin/tag.html
@@ -13,7 +13,7 @@
   <h1 class="title">标签</h1>
   <div class="entry-content">
     <section>
-      {% for tag in list %}
+      {% for tag in tags %}
       <a href="/tag/{{tag.pathname}}" data-tag="{{tag.name}}">{{tag.name}}({{tag.count}})</a>
       {% endfor %}
     </section>


### PR DESCRIPTION
1. 那个最近文章我叫她 `lastPostList` 了...
1. 修改了 tag 页面内变量, 直接使用了全局的数据
1. 使用了缓存, 因为发现查询量还是很大的, 缓存时间在 [src/common/config/cache.js](https://github.com/firekylin/firekylin/blob/master/src/common/config/cache.js) 内配置了, 本地测试缓存前、缓存后 SQL 执行情况正确