### PR TITLE
修复在文章编辑页添加的标签时字段 `pathname` 被encode

### DIFF
--- a/src/admin/controller/api/post.js
+++ b/src/admin/controller/api/post.js
@@ -237,7 +237,7 @@ ${post.markdown_content}`;
     let modelInstance = this.model('tag').setRelation(false), tagIds = [];
     let promises = tags.map(name =>
       modelInstance.where({name})
-        .thenAdd({name, pathname: encodeURIComponent(name)})
+        .thenAdd({name, pathname: name})
         .then(data => tagIds.push({tag_id: data.id, name: name}))
     );
     await Promise.all(promises);


### PR DESCRIPTION
在标签管理页面添加标签是没问题的, 在文章编辑页添加时被 encode 了, 导致很多地方二次 encode 时数据对不上, 比如: https://github.com/firekylin/firekylin/blob/0.15.6/src/home/model/tag.js#L48

并且浏览器会自动 decode, 这样导致获取的跟数据库内不同