### PR TITLE
新增host环境变量

### DIFF
--- a/src/common/config/config.js
+++ b/src/common/config/config.js
@@ -7,10 +7,18 @@ let portFile = think.ROOT_PATH + think.sep + 'port';
 if(think.isFile(portFile)) {
   port = fs.readFileSync(portFile, 'utf8');
 }
+
+let host;
+let hostFile = think.ROOT_PATH + think.sep + 'host';
+if(think.isFile(hostFile)) {
+	host = fs.readFileSync(hostFile, 'utf8');
+}
+
 /**
  * config
  */
 export default {
+  host: host || process.env.HOST || '0.0.0.0',
   port: port || process.env.PORT || 8360,
   resource_reg: /^(static\/|theme\/|[^\/]+\.(?!js|html|xml)\w+$)/
 };


### PR DESCRIPTION
可以在pm2.json的env里直接设置，防止在app/common/config/config.js里修改导致更新时被覆盖的问题