### PR TITLE
Fix: Image Lazyload Elements Index Mismatch

### DIFF
--- a/www/theme/firekylin/res/js/firekylin.js
+++ b/www/theme/firekylin/res/js/firekylin.js
@@ -261,7 +261,7 @@
       win.removeEventListener('scroll', lazyLoad);
       win.removeEventListener('resize', lazyLoad);
     } else {
-      for (var i = 0; i < lazyLoadImages.length; i++) {
+      for (var i = lazyLoadImages.length - 1; i > -1; i--) {
         var img = lazyLoadImages[i];
         if (lazyLoadShouldAppear(img, 300)) {
           img.src = img.getAttribute('data-src');


### PR DESCRIPTION
lazyLoadImagesp[] 为动态更新的 HTMLCollection type. 首屏多图时会导致 index 错位，所以 i 从最后一位开始遍历回 0 规避这个问题。

Reported by @xuexb .