### PR TITLE
remove invalid characters from XML in rss by add filter in nunjuncks

### DIFF
--- a/src/common/config/view.js
+++ b/src/common/config/view.js
@@ -23,6 +23,10 @@ export default {
           query.page = page;
           return pathname + build_query(query);
         });
+        env.addFilter('xml', str=> {
+          let NOT_SAFE_IN_XML = /[^\x09\x0A\x0D\x20-\xFF\x85\xA0-\uD7FF\uE000-\uFDCF\uFDE0-\uFFFD]/gm;
+          return str.replace(NOT_SAFE_IN_XML, '');
+        })
       }
     }
   }

--- a/view/home/rss.xml
+++ b/view/home/rss.xml
@@ -13,13 +13,13 @@
             <link>{{site_url}}/post/{{item.pathname}}.html</link>
             <description>
             {% if item.summary %}
-            {{item.summary}}
+            {{item.summary | xml}}
             {% if item.summary != item.content %}
             <p class="more">
                 <a href="{{site_url}}/post/{{item.pathname}}.html" title="{{item.title}}">[...]</a>
             </p>
             {% endif %}
-            {% else %}{{item.content}}{% endif %}
+            {% else %}{{item.content | xml}}{% endif %}
             </description>
             <pubDate>{{ item.create_time | utc }}</pubDate>
             <guid>{{site_url}}/post/{{item.pathname}}.html</guid>


### PR DESCRIPTION
#345 
sanitize 解决方案参照 https://stackoverflow.com/questions/14665288/removing-invalid-characters-from-xml-before-serializing-it-with-xmlserializer
在 view.js 中添加 nunjucks filter xml
在 rss.html 使用 xml filt