### PR TITLE
优化代码语言名称

### DIFF
--- a/www/theme/firekylin/res/css/article.css
+++ b/www/theme/firekylin/res/css/article.css
@@ -133,6 +133,11 @@ article pre b.name {
   color: #eee;
   pointer-events: none;
 }
+@media screen and (max-width:768px) {
+  article pre b.name {
+    font-size: 30px;
+  }
+}
 
 article img { 
   padding: 0;

--- a/www/theme/firekylin/res/js/firekylin.js
+++ b/www/theme/firekylin/res/js/firekylin.js
@@ -383,7 +383,7 @@
       html = '<ul>' + html + '</ul>';
 
       // 输出语言
-      if (lines.length > 3 && elem.className.match(/lang-(\w+)/)) {
+      if (lines.length > 3 && elem.className.match(/lang-(\w+)/) && RegExp.$1 !== 'undefined') {
         html += '<b class="name">' + RegExp.$1 + '</b>';
       }
 


### PR DESCRIPTION
1. 优化了配置代码语言名称不识别, 如: `nginxnginxnginx`, `javascriptjavascript`等时页面显示`undefined`
2. 优化语言名称较长时手机上显示不佳:
    - 修改前:
![image](https://user-images.githubusercontent.com/3872051/29241707-60fae478-7fb1-11e7-9fe8-fff307569644.png)
    - 修改后:
![image](https://user-images.githubusercontent.com/3872051/29241709-67b6b990-7fb1-11e7-8614-1a4b565efe51.png)
