### PR TITLE
fixed mathjax regex error

### DIFF
--- a/src/common/service/marked-with-mathjax.js
+++ b/src/common/service/marked-with-mathjax.js
@@ -44,8 +44,7 @@ async function _mathSpanRender(text) {
       const mathContent = await _renderMathJax(cap[1]);
 
       text = text.substring(0, strStart) + mathContent + text.substring(strEnd);
-      reg.lastIndex += mathContent.length;
-
+      reg.lastIndex += mathContent.length - cap[0].length;
     } else {
       break;
     }


### PR DESCRIPTION
修复渲染 MathJax 时，正则匹配 `lastIndex` 增量的错误

以下文本可以复现 BUG
```
`$1.6152381897$`，`$ 1.6151500386$`
```