### PR TITLE
Fix #427 User Email should not be editable

### DIFF
--- a/www/static/src/admin/component/user_create.jsx
+++ b/www/static/src/admin/component/user_create.jsx
@@ -55,8 +55,8 @@ module.exports = class extends Base {
         setTimeout(() => this.redirect('user/list'), 1000);
         break;
       case 'getUserInfo':
-        this.setState({userInfo: data});
         this.hasEmail = !!data.email;
+        this.setState({userInfo: data});
         break;
     }
   }


### PR DESCRIPTION
https://github.com/firekylin/firekylin/pull/428/files#diff-154b985cfa5089c61d24436ad02588a4L120
`getProps()` is checking for `this.email` which is not set until after component rerendering from `this.setState({userInfo: data})`, therefore, moving `this.hasEmail = !!data.email` before `setState` fixes #427.