### PR TITLE
fix: 解决七牛SDK升级v7.1.*后，没有更新七牛SDK API接口的bug

### DIFF
--- a/src/admin/service/upload/qiniu.js
+++ b/src/admin/service/upload/qiniu.js
@@ -1,24 +1,71 @@
 const qiniu = require('qiniu');
 const Base = require('./base');
 
+/**
+ * makeUploadToken
+ * @desc 构建上传认证凭证
+ *
+ * @param {String} key - 上传到七牛后保存的路径
+ * @param {string} bucket - 要上传的空间
+ * @param {string} accessKey - 七牛秘钥AccessKey
+ * @param {string} secretKey - 七牛秘钥SecretKey
+ *
+ * @returns {string} - 上传认证凭证
+ */
+const makeUploadToken = (saveKey, bucket, accessKey, secretKey) => {
+  const MAC = new qiniu.auth.digest.Mac(
+    accessKey,
+    secretKey,
+  );
+  const putPolicy = new qiniu.rs.PutPolicy({
+    scope: `${bucket}`,
+    saveKey: (saveKey && (`${saveKey}`).length) ? saveKey : null
+  });
+  return putPolicy.uploadToken(MAC);
+};
+
+const QINIU_CONF = new qiniu.conf.Config();
+// 是否使用https域名
+QINIU_CONF.useHttpsDomain = true;
+// 上传是否使用cdn加速
+QINIU_CONF.useCdnDomain = true;
+// 机房 Zone 对象
+// 华东 qiniu.zone.Zone_z0
+// 华北 qiniu.zone.Zone_z1
+// 华南 qiniu.zone.Zone_z2
+// 北美 qiniu.zone.Zone_na0
+// QINIU_CONF.zone = qiniu.zone.Zone_z0; // 华东机房
+
+const formUploader = new qiniu.form_up.FormUploader(QINIU_CONF);
+
 module.exports = class extends Base {
   // 导入方法
   async uploadMethod(filename, config) {
-    qiniu.conf.ACCESS_KEY = config.accessKey;
-    qiniu.conf.SECRET_KEY = config.secretKey;
-    const savePath = this.getSavePath(filename, config.prefix);
-    const token = new qiniu.rs.PutPolicy(`${config.bucket}:${savePath}`).token();
-    const extra = new qiniu.io.PutExtra();
+    const saveKey = (config.prefix && (`${config.prefix}`).length) ? `${config.prefix.replace(/\/$/, '')}/$(year)$(mon)$(day)/$(etag)$(ext)` : null;
     return new Promise((resolve, reject) => {
-      qiniu.io.putFile(token, savePath, filename, extra, (err, ret) => {
-        if (err) {
-          reject(err);
-        } else {
-          const origin = this.getAbsOrigin(config.origin);
-          const compeletePath = `${origin}/${ret.key}`;
-          resolve(compeletePath);
+      formUploader.putFile(
+        makeUploadToken(saveKey, config.bucket, config.accessKey, config.secretKey),
+        null,
+        filename,
+        (new qiniu.form_up.PutExtra({
+          // fname: '', // 请求体中的文件的名称
+          // params: '', // 额外参数设置，参数名称必须以x:开头
+          // mimeType: '', // 指定文件的mimeType
+          // crc32: '', // 指定文件的crc32值
+          // checkCrc: '', // 指定是否检测文件的crc32值
+        })),
+        (err, ret) => {
+          if (!err) {
+            // 上传成功， 处理返回值
+            const origin = this.getAbsOrigin(config.origin);
+            const compeletePath = `${origin}/${ret.key}`;
+            resolve(compeletePath);
+          } else {
+            // 上传失败报错
+            reject(err);
+          }
         }
-      });
+      );
     });
   }
 

--- a/src/admin/service/upload/qiniu.js
+++ b/src/admin/service/upload/qiniu.js
@@ -5,7 +5,7 @@ const Base = require('./base');
  * makeUploadToken
  * @desc 构建上传认证凭证
  *
- * @param {String} key - 上传到七牛后保存的路径
+ * @param {String} saveKey - 自定义资源名
  * @param {string} bucket - 要上传的空间
  * @param {string} accessKey - 七牛秘钥AccessKey
  * @param {string} secretKey - 七牛秘钥SecretKey
@@ -26,9 +26,9 @@ const makeUploadToken = (saveKey, bucket, accessKey, secretKey) => {
 
 const QINIU_CONF = new qiniu.conf.Config();
 // 是否使用https域名
-QINIU_CONF.useHttpsDomain = true;
+// QINIU_CONF.useHttpsDomain = true;
 // 上传是否使用cdn加速
-QINIU_CONF.useCdnDomain = true;
+// QINIU_CONF.useCdnDomain = true;
 // 机房 Zone 对象
 // 华东 qiniu.zone.Zone_z0
 // 华北 qiniu.zone.Zone_z1
@@ -41,6 +41,7 @@ const formUploader = new qiniu.form_up.FormUploader(QINIU_CONF);
 module.exports = class extends Base {
   // 导入方法
   async uploadMethod(filename, config) {
+    // @see https://developer.qiniu.com/kodo/manual/1235/vars#magicvar
     const saveKey = (config.prefix && (`${config.prefix}`).length) ? `${config.prefix.replace(/\/$/, '')}/$(year)$(mon)$(day)/$(etag)$(ext)` : null;
     return new Promise((resolve, reject) => {
       formUploader.putFile(


### PR DESCRIPTION
七牛SDK(Node.js)由v6升级到v7时，SDK中putFile的接口有变动，导致原有功能出现异常。

本次PR保留了原有的上传规则，利用七牛[上传策略](https://developer.qiniu.com/kodo/manual/1206/put-policy)中的saveKey，配置其[魔法变量](https://developer.qiniu.com/kodo/manual/1235/vars#magicvar)，上传后，保存key值规则`/{prefix}/$(year)$(mon)$(day)/$(etag)$(ext)`。