### PR TITLE
fix invalid func, request.defaults

### DIFF
--- a/src/admin/controller/api/file.js
+++ b/src/admin/controller/api/file.js
@@ -20,12 +20,12 @@ function ip2long(ip) {
   return longValue;
 }
 
-request.defaults({
+const reqIns = request.defaults({
   strictSSL: false,
   rejectUnauthorized: false
 });
 
-const getFileContent = think.promisify(request.get, request);
+const getFileContent = think.promisify(reqIns.get, reqIns);
 const writeFileAsync = think.promisify(fs.writeFile, fs);
 const unlinkAsync = think.promisify(fs.unlink, fs);
 const lookupAsync = think.promisify(dns.lookup, dns);

--- a/src/admin/controller/api/system.js
+++ b/src/admin/controller/api/system.js
@@ -6,13 +6,13 @@ const request = require('request');
 const pack = require('../../../../package.json');
 const Base = require('./base');
 
-request.defaults({
+const reqIns = request.defaults({
   timeout: 1000,
   strictSSL: false,
   rejectUnauthorized: false
 });
 
-const reqIns = think.promisify(request.get);
+const reqInsAsync = think.promisify(reqIns.get);
 
 module.exports = class extends Base {
 
@@ -24,7 +24,7 @@ module.exports = class extends Base {
   async getAction() {
     let needUpdate = false;
     try {
-      let res = await reqIns('http://firekylin.org/release/v1/.latest');
+      let res = await reqInsAsync('http://firekylin.org/release/v1/.latest');
       let onlineVersion = res.body.trim();
       if(semver.gt(onlineVersion, pack.version)) {
         needUpdate = onlineVersion;
@@ -71,7 +71,7 @@ module.exports = class extends Base {
       case '1':
       default:
         return new Promise((resolve, reject) => {
-          request({uri: 'http://firekylin.org/release/v1/latest.tar.gz'})
+          reqIns({uri: 'http://firekylin.org/release/v1/latest.tar.gz'})
           .pipe(fs.createWriteStream(path.join(think.RESOURCE_PATH, 'latest.tar.gz')))
           .on('close', resolve)
           .on('error', reject)

--- a/src/home/service/comment.js
+++ b/src/home/service/comment.js
@@ -1,13 +1,13 @@
 const request = require('request');
 
-request.defaults({
+const reqIns = request.defaults({
   strictSSL: false,
   rejectUnauthorized: false
 });
 
 const _ = {
-  get: think.promisify(request, request),
-  post: think.promisify(request.post, request)
+  get: think.promisify(reqIns, reqIns),
+  post: think.promisify(reqIns.post, reqIns)
 };
 
 module.exports = class extends think.Service {


### PR DESCRIPTION
- 起因：

今天发现进入后台后系统概况信息迟迟不出现，打开控制台发现这条 system 请求耗时特别长，刷新几次都需要几十秒
![image](https://user-images.githubusercontent.com/25625252/51424034-3f0ff200-1c03-11e9-9ce5-0579ddab1bdd.png)

- 经过：

大概是卡在了这里，获取 latest version 时间过长
https://github.com/firekylin/firekylin/blob/bd1de31eb07f959910a040471cf09356a139c388/src/admin/controller/api/system.js#L26-L34

没有触发这里设置的 defaults
https://github.com/firekylin/firekylin/blob/bd1de31eb07f959910a040471cf09356a139c388/src/admin/controller/api/system.js#L9-L13

随手翻了文档，request.defaults 返回一个新实例，不改变原对象
https://github.com/request/request#requestdefaultsoptions
![image](https://user-images.githubusercontent.com/25625252/51424115-7d59e100-1c04-11e9-9388-840023d095ff.png)

- 结果：

顺手把项目里用过 request.defaults 的地方改了改
