### PR TITLE
修复了www/theme/firekylin/layout.html文件中的全局样式由于错误的格式化导致大括号被错误拆解并换行带来的解析错误。

### DIFF
--- a/www/theme/firekylin/layout.html
+++ b/www/theme/firekylin/layout.html
@@ -19,76 +19,40 @@
   <link rel="stylesheet" href="/theme/{{options.theme}}/res/css/all.css" type="text/css" data-ls="css_firekylin">
   {% if themeConfig.sidebarBackground or themeConfig.sidebarBackgroundColor or themeConfig.customCSS or themeConfig.sidebarColor %}
   <style>
-    {
-      % if themeConfig.sidebarBackground or themeConfig.sidebarBackgroundColor %
-    }
+    {% if themeConfig.sidebarBackground or themeConfig.sidebarBackgroundColor %}
 
     #sidebar {
-        {
-        % if themeConfig.sidebarBackground %
-      }
+        {% if themeConfig.sidebarBackground %}
 
       background-image: url('{{themeConfig.sidebarBackground}}');
       background-size:cover;
 
-        {
-        % endif %
-      }
+        {% endif %}
 
-        {
-        % if themeConfig.sidebarBackgroundColor %
-      }
+        {% if themeConfig.sidebarBackgroundColor %}
 
-      background-color: {
-          {
-          themeConfig.sidebarBackgroundColor
-        }
-      }
+      background-color: {{ themeConfig.sidebarBackgroundColor }};
 
-      ;
-
-        {
-        % endif %
-      }
+        {% endif %}
     }
 
-      {
-      % endif %
-    }
+      {% endif %}
 
-      {
-      % if themeConfig.sidebarColor %
-    }
+      {% if themeConfig.sidebarColor %}
 
     #sidebar .profile span,
     #sidebar .buttons li a,
     #sidebar .buttons li a:hover {
-      color: {
-          {
-          themeConfig.sidebarColor
-        }
-      }
-
-      ;
+      color: {{ themeConfig.sidebarColor }};
     }
 
-      {
-      % endif %
-    }
+      {% endif %}
 
-      {
-      % if themeConfig.customCSS %
-    }
+      {% if themeConfig.customCSS %}
 
-      {
-        {
-        themeConfig.customCSS | safe
-      }
-    }
+      {{ themeConfig.customCSS | safe }}
 
-      {
-      % endif %
-    }
+      {% endif %}
   </style>
   {% endif %}
 </head>


### PR DESCRIPTION
使用发现默认主题修改不生效，定位发现是www/theme/firekylin/layout.html中headers里的style部分由于{% %} 和{{ }} 被错误的拆解换行导致模板不能被正确解析。