### PR TITLE
增加文章回收站

### DIFF
--- a/src/admin/controller/api/post.js
+++ b/src/admin/controller/api/post.js
@@ -38,12 +38,16 @@ module.exports = class extends Base {
         where.user_id = this.userInfo.id;
       }
 
-      if(this.get('status')) {
-        where.status = this.get('status');
+      const {status, keyword, cate: cateText} = this.get();
+      if(status) {
+        where.status = status;
+      } else {
+        //已删除的文章不展示在全部列表里
+        where.status = ['!=', 4];
       }
 
-      if(this.get('keyword')) {
-        let keywords = this.get('keyword').split(/\s+/g);
+      if(keyword) {
+        let keywords = keyword.split(/\s+/g);
         if(keywords.indexOf(':public') > -1 || keywords.indexOf(':private') > -1) {
           where.is_public = Number(keywords.indexOf(':public') > -1);
           keywords = keywords.filter(word => word !== ':public' && word !== ':private');
@@ -53,8 +57,8 @@ module.exports = class extends Base {
         }
       }
 
-      if(this.get('cate')) {
-        let cate = parseInt(this.get('cate'));
+      if(cateText) {
+        const cate = parseInt(cateText);
         if(!isNaN(cate)) {
           this.modelInstance.join({
             table: 'post_cate',

--- a/www/static/src/routes/post/list/list.tsx
+++ b/www/static/src/routes/post/list/list.tsx
@@ -80,6 +80,9 @@ class PostListForm extends React.Component<PostListProps, {}> {
                         <TabPane tab="已拒绝" key="2">
                             <PostListTable {...this.props} />
                         </TabPane>
+                        <TabPane tab="回收站" key="4">
+                            <PostListTable {...this.props} />
+                        </TabPane>
                     </Tabs>
                 </div>
             </>

--- a/www/static/src/routes/post/list/table/list-table.tsx
+++ b/www/static/src/routes/post/list/table/list-table.tsx
@@ -12,14 +12,18 @@ const confirm = Modal.confirm;
 @inject('postStore')
 @observer
 class PostListTable extends React.Component<PostListProps, {}> {
-    delete(id: number) {
+    delete(id: number, force: boolean = false) {
         confirm({
             title: '提示',
-            content: '确定删除吗?',
+            content: `确定${force ? '彻底' : ''}删除吗?`,
             onOk: () => {
-                this.props.postStore.deletePostById(id);
+                this.props.postStore.deletePostById(id, force);
             }
         });
+    }
+
+    cancel(id: number) {
+        this.props.postStore.cancelPostById(id);
     }
 
     pass(id: number) {
@@ -39,6 +43,14 @@ class PostListTable extends React.Component<PostListProps, {}> {
                     <Button onClick={() => this.delete(post.id)} style={{ marginLeft: 8 }} type="danger" icon="delete" size="small">删除</Button>
                 </>
             );
+        } else if(status === '4') {
+            return (
+                <>
+
+                    <Button onClick={() => this.cancel(post.id)} type="primary" icon="edit" size="small">撤销</Button>
+                    <Button onClick={() => this.delete(post.id, true)} style={{ marginLeft: 8 }} type="danger" icon="delete" size="small">删除</Button>
+                </>
+            )
         } else {
             return (
                 <>

--- a/www/static/src/routes/post/post.store.ts
+++ b/www/static/src/routes/post/post.store.ts
@@ -109,19 +109,25 @@ class PostStore {
   }
 
   // 删除文章
-  deletePostById(id: number) {
-    http.post<any>(`/admin/api/post/${id}?method=delete`)
-      .subscribe(
-        res => {
-          if (res.errno === 0) {
-              message.success('删除成功');
-              this.getPostList();
-          }
-        },
-        err => {
-          message.error(err);
+  deletePostById(id: number, force: boolean = false) {
+    let handle;
+    if(force) {
+      handle = http.post<any>(`/admin/api/post/${id}?method=delete`);
+    } else {
+      handle = http.post<any>(`/admin/api/post/${id}?method=put`, {status: 4});
+    }
+  
+    handle.subscribe(
+      res => {
+        if (res.errno === 0) {
+            message.success('删除成功');
+            this.getPostList();
         }
-      );
+      },
+      err => {
+        message.error(err);
+      }
+    );
   }
   // 通过
   passPostById(id: number) {
@@ -152,6 +158,21 @@ class PostStore {
         err => {
           message.error(err);
         }
+    );
+  }
+  //撤销删除
+  cancelPostById(id: number) {
+    http.post<any>(`/admin/api/post/${id}?method=put`, {status: 3})
+    .subscribe(
+      res => {
+        if(res.errno === 0) {
+          message.success('撤销删除成功');
+          this.getPostList();
+        }
+      },
+      err => {
+        message.error(err);
+      }
     );
   }
   // 重置

--- a/www/static/src/utils/tools.ts
+++ b/www/static/src/utils/tools.ts
@@ -33,6 +33,7 @@ function getStatusText(status: number, createTime?: Date) {
             statusText = '已发布';
         }
         break;
+      case 4: statusText = '已删除'; break;
       default:
     }
     return statusText;


### PR DESCRIPTION
close #539 #730 

ps. 基于不修改数据结构的情况新增了 `status=4` 的状态用来表示已删除，带来的好处是之前所有判断已发布的文章的逻辑不需要修改，坏处是目前只能 `status=3` 和 `status=4` 进行互相映射，其它的审核，通过，拒绝状态因为共用一个字段修改后无法修改回之前的状态了。好在目前审核的文章没有删除的操作，所以还好。
