### PR TITLE
Security: Use of eval() in Nunjucks template configuration

### DIFF
--- a/src/common/config/adapter/view.js
+++ b/src/common/config/adapter/view.js
@@ -22,7 +22,6 @@ module.exports = {
     beforeRender(env, nunjucks) {
       env.addGlobal('think', think);
       env.addGlobal('JSON', JSON);
-      env.addGlobal('eval', eval);
 
       env.addFilter('utc', time => (new Date(time)).toUTCString());
       env.addFilter('pagination', function(page, pageUrl) {


### PR DESCRIPTION
## Summary

Security: Use of eval() in Nunjucks template configuration

## Problem

**Severity**: `Critical` | **File**: `src/common/config/adapter/view.js:L22`

In src/common/config/adapter/view.js, line 22, eval is added as a global function to the Nunjucks template engine. This allows arbitrary JavaScript code execution through templates, leading to remote code execution (RCE) vulnerability.

## Solution

Remove the line 'env.addGlobal('eval', eval);' as it enables arbitrary code execution. If template evaluation is needed, use a sandboxed solution.

## Changes

- `src/common/config/adapter/view.js` (modified)